### PR TITLE
Fix syntax error.

### DIFF
--- a/ets_to_hass.rb
+++ b/ets_to_hass.rb
@@ -148,7 +148,7 @@ class ConfigurationImporter
         end
         o = {
           name: f['Name'].freeze,
-          type:,
+          type: type,
           ga: f['GroupAddressRef'].map { |g| g['RefId'].freeze },
           custom: {} # custom values
         }.merge(info)


### PR DESCRIPTION
d340a7dbd63451f0e71c69457f5adc280c985177 fails to start with this error:
```./ets_to_hass.rb homeass                                                                                                                                                              14:13:16
./ets_to_hass.rb:151: syntax error, unexpected ','
          type:,
./ets_to_hass.rb:152: syntax error, unexpected ',', expecting `end'
....map { |g| g['RefId'].freeze },
./ets_to_hass.rb:154: syntax error, unexpected '}', expecting `end'
        }.merge(info)
./ets_to_hass.rb:244: syntax error, unexpected `end', expecting end-of-input
```
Changing line 151 from `type: ,` to `type: type,` fixes this error. 