### PR TITLE
Update ets_to_hass - missing --addr argument

### DIFF
--- a/bin/ets_to_hass
+++ b/bin/ets_to_hass
@@ -29,7 +29,8 @@ opts = GetoptLong.new(
   ['--full-name', '-n', GetoptLong::NO_ARGUMENT],
   ['--specific', '-s', GetoptLong::REQUIRED_ARGUMENT],
   ['--trace', '-t', GetoptLong::REQUIRED_ARGUMENT],
-  ['--output', '-o', GetoptLong::REQUIRED_ARGUMENT]
+  ['--output', '-o', GetoptLong::REQUIRED_ARGUMENT],
+  ['--addr', '-a', GetoptLong::REQUIRED_ARGUMENT]
 )
 
 options = {}


### PR DESCRIPTION
Currently using `--addr` doesn't work.
```
./bin/ets_to_hass: unrecognized option `--addr'
/opt/homebrew/Cellar/ruby/3.2.2_1/lib/ruby/3.2.0/getoptlong.rb:649:in `set_error': unrecognized option `--addr' (GetoptLong::InvalidOption)
	from /opt/homebrew/Cellar/ruby/3.2.2_1/lib/ruby/3.2.0/getoptlong.rb:749:in `get'
	from /opt/homebrew/Cellar/ruby/3.2.2_1/lib/ruby/3.2.0/getoptlong.rb:861:in `block in each'
	from /opt/homebrew/Cellar/ruby/3.2.2_1/lib/ruby/3.2.0/getoptlong.rb:860:in `loop'
	from /opt/homebrew/Cellar/ruby/3.2.2_1/lib/ruby/3.2.0/getoptlong.rb:860:in `each'
	from ./bin/ets_to_hass:39:in `<main>'

```
I'm not a Ruby developer myself but I think I found the issue.
I tested locally it works fine with this addition.